### PR TITLE
Add function simulateExecutables

### DIFF
--- a/ReleaseChecks.mo
+++ b/ReleaseChecks.mo
@@ -27,9 +27,45 @@ package ReleaseChecks
     for packageName in libraries loop
       Internal.inspectPackage(packageName, fileNameSuccessful, fileNameFailed);
     end for;
-    annotation (Documentation(info="<html><p>
+    annotation (__Dymola_interactive=true, Documentation(info="<html><p>
 Translate all executable (= having an <code>experiment.StopTime</code> annotation) blocks/models of the listed <code>libraries</code> in pedantic mode.</p></html>"));
   end printExecutables;
+
+  function simulateExecutables "Recursively simulate blocks/models and generate CSV files for simulation results"
+    extends Modelica.Icons.Function;
+
+    import Modelica.Utilities.Files.loadResource;
+    import Modelica.Utilities.Streams.print;
+
+    input String libraries[:] = {"Modelica", "ModelicaTest"} "Libraries that shall be inspected";
+    input Boolean incrementalRun = true "= true, if only the failed models/blocks from a previous run are simulated, otherwise run all models/blocks";
+    input Boolean keepResultFile = false "= true, if the MAT file containing the simulation result data is to be kept";
+    input Integer numberOfIntervals = 5000 "Number of output points";
+    input Real tolerance = 1e-6 "Solver tolerance";
+    input String compiler = "vs" "Compiler type, for example, \"vs\"";
+    input String compilerSettings[:] = {"MSVCDir=c:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build"} "Compiler settings in name=value pairs";
+    input String gitURL = "" "Run command \"git config --get remote.origin.url\"";
+    input String gitRevision = "" "Run command \"git rev-parse --short HEAD\"";
+    input String description = "Reg test MSL v4.0.0-beta.1" "Description";
+
+  protected
+    String packageName;
+    String directory "Directory structure containing the simulation data";
+    Integer nr[3] "Number of failed {checks, translations, simulations} per package";
+    String osver = Internal.command("ver") "OS version information";
+    String hostname = Internal.command("hostname") "Host name";
+    String user = Internal.command("echo %username%") "User name";
+  algorithm
+
+    // Inspect packages
+    for packageName in libraries loop
+      directory := loadResource("modelica://" + packageName + "/Resources/Reference");
+      nr := Internal.inspectPackageEx(packageName, directory, incrementalRun, keepResultFile, numberOfIntervals, tolerance, compiler, compilerSettings, osver, hostname, user, description, gitURL, gitRevision);
+      print("Result for package \"" + packageName + "\": " + String(nr[1]) + " failed checks, " + String(nr[2]) + " failed translations, " + String(nr[3]) + " failed simulations");
+    end for;
+    annotation (__Dymola_interactive=true, Documentation(info="<html><p>
+Simulate all executable (= having an <code>experiment.StopTime</code> annotation) blocks/models of the listed <code>libraries</code> and generate CSV for the simulation data.</p></html>"));
+  end simulateExecutables;
 
   function countClassesInPackage "Recursively count public, non-partial, non-internal and non-obsolete classes in package"
     extends Modelica.Icons.Function;
@@ -69,7 +105,7 @@ Translate all executable (= having an <code>experiment.StopTime</code> annotatio
         end if;
       end for;
     end if;
-    annotation (Documentation(info="<html><p>
+    annotation (__Dymola_interactive=true, Documentation(info="<html><p>
 Modified version of <a href=\"modelica://ModelManagement.Structure.AST.Examples.countModelsInPackage\">
 countModelsInPackage</a> from ModelManagement library of Dymola</p></html>"));
   end countClassesInPackage;
@@ -81,7 +117,7 @@ countModelsInPackage</a> from ModelManagement library of Dymola</p></html>"));
     input String directory = Modelica.Utilities.Files.loadResource("modelica://" + name + "/Resources/help") "Directory of exported HTML files";
   algorithm
     exportHTMLDirectory(name, directory);
-    annotation (Documentation(info="<html><p>
+    annotation (__Dymola_interactive=true, Documentation(info="<html><p>
 Generate HTML documentation from Modelica model or package in Dymola</p></html>"));
   end genDoc;
 
@@ -104,6 +140,7 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
       String StopTime;
       Boolean OK;
       String logStat;
+	  String fullName;
       AST.ClassAttributes classAttributes;
     algorithm
       logStat := "";
@@ -134,7 +171,315 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
           end if;
         end if;
       end for;
+	  annotation(__Dymola_interactive=true);
     end inspectPackage;
+
+    function inspectPackageEx "Simulate all executables blocks/models of a package and generate simulation results"
+      extends Modelica.Icons.Function;
+
+      import Modelica.Utilities.Files.createDirectory;
+      import Modelica.Utilities.Files.exist;
+      import Modelica.Utilities.Files.fullPathName;
+      import Modelica.Utilities.Files.move;
+      import Modelica.Utilities.Files.removeFile;
+      import Modelica.Utilities.Streams.print;
+      import Modelica.Utilities.Streams.readFile;
+      import Modelica.Utilities.Strings.isEmpty;
+      import Modelica.Utilities.Strings.replace;
+      import Modelica.Utilities.System.getTime;
+      import ModelManagement.Structure.AST;
+
+      input String packageName "Package to be inspected";
+      input String directory "Directory structure containing the simulation data";
+      input Boolean incrementalRun = true "= true, if only the failed models/blocks from a previous run are simulated, otherwise run all models/blocks";
+      input Boolean keepResultFile = false "= true, if the MAT file containing the simulation result data is kept";
+      input Integer numberOfIntervals = 5000 "Number of output points";
+      input Real tolerance = 1e-6 "Solver tolerance";
+      input String compiler "Compiler type, for example, \"vs\"";
+      input String compilerSettings[:] "Compiler settings in name=value pairs";
+      input String osver "OS version information";
+      input String hostname "Host name";
+      input String user "User name";
+      input String description "Description";
+      input String gitURL "Run command \"git config --get remote.origin.url\"";
+      input String gitRevision "Run command \"git rev-parse --short HEAD\"";
+      output Integer nr[3] = zeros(3) "Number of failed {checks, translations, simulations}";
+    protected
+      String localClasses[:];
+      String StartTime;
+      String StopTime;
+      String Tolerance;
+      String Interval;
+      String modelDirectory;
+      String logStat;
+      String MATFileName;
+      String CSVFileName;
+      String varNames[:];
+      String fullName;
+      Boolean OK;
+      Integer n;
+      Real traj[:, :];
+      Real traj_transposed[:, :];
+      Real startTime;
+      Real stopTime;
+      Real interval;
+      Real usedTolerance;
+      Boolean isDefaultStartTime;
+      Boolean isDefaultInterval;
+      Boolean isDefaultTolerance;
+      Integer sec, min, hour, day, mon, year;
+      String timeString;
+      AST.ClassAttributes classAttributes;
+    algorithm
+      localClasses := AST.ClassesInPackage(packageName);
+      StartTime := "";
+      StopTime := "";
+      Tolerance := "";
+      Interval := "";
+      modelDirectory := "";
+      logStat := "";
+      MATFileName := "";
+      CSVFileName := "";
+      varNames := fill("", 0);
+      n := 0;
+      traj := fill(0, 0, 0);
+      traj_transposed := fill(0, 0, 0);
+      startTime := 0;
+      stopTime := 1;
+      interval := 0;
+      isDefaultStartTime := false;
+      isDefaultInterval := false;
+      isDefaultTolerance := false;
+      usedTolerance := tolerance;
+      for name in localClasses loop
+        fullName := packageName + "." + name;
+        classAttributes := AST.GetClassAttributes(fullName);
+        if classAttributes.restricted == "package" then
+          nr := nr + inspectPackageEx(fullName, directory, incrementalRun, keepResultFile, numberOfIntervals, tolerance, compiler, compilerSettings, osver, hostname, user, description, gitURL, gitRevision);
+
+        elseif classAttributes.restricted == "model" or classAttributes.restricted == "block" then
+          StopTime := AST.GetAnnotation(fullName, "experiment.StopTime");
+          if not isEmpty(StopTime) then
+            (, stopTime) := scanReal(StopTime, 1.0);
+            StartTime := AST.GetAnnotation(fullName, "experiment.StartTime");
+            (isDefaultStartTime, startTime) := scanReal(StartTime, 0.0);
+            Tolerance := AST.GetAnnotation(fullName, "experiment.Tolerance");
+            (isDefaultTolerance, usedTolerance) := scanReal(Tolerance, tolerance);
+            if not isDefaultTolerance and usedTolerance >= 2e-12 then
+              usedTolerance := usedTolerance * 0.1;
+            end if;
+            Interval := AST.GetAnnotation(fullName, "experiment.Interval");
+            (isDefaultInterval, interval) := scanReal(Interval, (stopTime - startTime)/numberOfIntervals);
+            if not isDefaultInterval then
+              interval := interval * 0.5;
+            end if;
+            modelDirectory := fullPathName(directory + "/" + replace(fullName, ".", "/"));
+            createDirectory(modelDirectory);
+
+            if not incrementalRun or not exist(fullPathName(modelDirectory + "/check_passed.log")) or not exist(fullPathName(modelDirectory + "/translate_passed.log")) or not exist(fullPathName(modelDirectory + "/simulate_passed.log")) then
+              SetDymolaCompiler(compiler, compilerSettings);
+              Evaluate := false;
+              OutputCPUtime := false;
+
+              // Remove log files
+              removeFile(fullPathName(modelDirectory + "/check_passed.log"));
+              removeFile(fullPathName(modelDirectory + "/check_failed.log"));
+              removeFile(fullPathName(modelDirectory + "/translate_passed.log"));
+              removeFile(fullPathName(modelDirectory + "/translate_failed.log"));
+              removeFile(fullPathName(modelDirectory + "/simulate_passed.log"));
+              removeFile(fullPathName(modelDirectory + "/simulate_failed.log"));
+              removeFile(fullPathName(modelDirectory + "/compare_passed.log"));
+              removeFile(fullPathName(modelDirectory + "/compare_failed.log"));
+              removeFile(fullPathName(modelDirectory + "/creation.txt"));
+              // Remove simulation data
+              removeFile(fullPathName(modelDirectory + "/" + name + ".csv"));
+              removeFile(fullPathName(modelDirectory + "/" + name + ".mat"));
+
+              // Write meta data
+              logStat = Internal.getCreation(name, fullName, startTime, stopTime, interval, usedTolerance, numberOfIntervals, isDefaultStartTime, isDefaultInterval, isDefaultTolerance, compiler, compilerSettings, osver, hostname, user, description, gitURL, gitRevision);
+              print(logStat, fullPathName(modelDirectory + "/creation.txt"));
+
+              // Check model
+              OK := checkModel(fullName);
+              (logStat, , , ) := getLastError();
+              if OK then
+                print(logStat, fullPathName(modelDirectory + "/check_passed.log"));
+
+                // Translate model
+                OK := translateModel(fullName);
+                (logStat, , , ) := getLastError();
+                if OK then
+                  print(logStat, fullPathName(modelDirectory + "/translate_passed.log"));
+                  Advanced.StoreProtectedVariables := true;
+                  Advanced.EfficientMinorEvents := false;
+                  OK := experimentSetupOutput(textual=false, doublePrecision=true, states=true, derivatives=true, inputs=true, outputs=true, auxiliaries=true, equidistant=true, events=true, debug=false);
+
+                  // Simulate model
+                  OK := simulateModel(problem=fullName, startTime=startTime, stopTime=stopTime, tolerance=usedTolerance, method="Dassl", outputInterval=interval, resultFile=name);
+                  if OK then
+                    move("dslog.txt", fullPathName(modelDirectory + "/simulate_passed.log"));
+
+                    // Write result variables as CSV file
+                    MATFileName := name + ".mat";
+                    CSVFileName := fullPathName(modelDirectory + "/" + name + ".csv");
+                    n := readTrajectorySize(MATFileName);
+                    varNames := readFile(fullPathName(modelDirectory + "/comparisonSignals.txt"));
+                    if varNames[1] == "time" then
+                      varNames[1] := "Time";
+                    end if;
+                    traj := readTrajectory(MATFileName, varNames, n);
+                    traj_transposed := transpose(traj);
+                    if varNames[1] == "Time" then
+                      varNames[1] := "time";
+                    end if;
+                    DataFiles.writeCSVmatrix(CSVFileName, varNames, traj_transposed, separator=",", quoteAllHeaders=true);
+
+                    // Move or remove MAT file
+                    if keepResultFile then
+                      move(MATFileName,  fullPathName(modelDirectory + "/" + name + ".mat"));
+                    else
+                      removeFile(MATFileName);
+                    end if;
+                  else
+                    nr[3] := nr[3] + 1;
+                    move("dslog.txt", fullPathName(modelDirectory + "/simulate_failed.log"));
+                  end if;
+                else
+                  nr[2] := nr[2] + 1;
+                  print(logStat, fullPathName(modelDirectory + "/translate_failed.log"));
+                end if;
+              else
+                nr[1] := nr[1] + 1;
+                print(logStat, fullPathName(modelDirectory + "/check_failed.log"));
+              end if;
+            end if;
+          end if;
+        end if;
+      end for;
+	  annotation(__Dymola_interactive=true);
+    end inspectPackageEx;
+
+    function scanReal "Scan Real value from string"
+      extends Modelica.Icons.Function;
+      input String str "String";
+      input Real default "Default value if scan fails";
+      output Boolean isDefaultUsed "= true, if default value is used";
+      output Real val "Return value";
+    protected
+      Integer index;
+    algorithm
+      if Modelica.Utilities.Strings.isEmpty(str) then
+        isDefaultUsed := true;
+        val := default;
+      else
+        isDefaultUsed := false;
+        index := Modelica.Utilities.Strings.find(str, "=");
+        val := Modelica.Utilities.Strings.scanReal(str, index + 1);
+      end if;
+    end scanReal;
+
+    function command "System command execution"
+      extends Modelica.Icons.Function;
+      input String commandString "Command string";
+      output String returnString "Return string";
+    protected
+      String lines[:];
+      Integer rc;
+    algorithm
+      rc := Modelica.Utilities.System.command(commandString + ">cmd.txt");
+      lines := Modelica.Utilities.Streams.readFile("cmd.txt");
+      returnString := "";
+      for i in 1:size(lines, 1) loop
+        returnString := returnString + lines[i];
+      end for;
+    end command;
+
+    impure function getCreation "Return creation meta data"
+      extends Modelica.Icons.Function;
+      input String modelIdent = "" "Model indent";
+      input String modelName = "" "Model name";
+      input Real startTime "Start time";
+      input Real stopTime "Stop time";
+      input Real interval "Interval";
+      input Real tolerance "Solver tolerance";
+      input Integer numberOfIntervals "Number of intervals";
+      input Boolean isDefaultStartTime "= true, if start time is the default start time";
+      input Boolean isDefaultInterval "= true, if start time is the default interval";
+      input Boolean isDefaultTolerance "= true, if start time is the default solver tolerance";
+      input String compiler "Compiler type, for example, \"vs\"";
+      input String compilerSettings[:] "Compiler settings in name=value pairs";
+      input String osver "OS version information";
+      input String hostname "Host name";
+      input String user "User name";
+      input String description "Description";
+      input String gitURL "Run command \"git config --get remote.origin.url\"";
+      input String gitRevision "Run command \"git rev-parse --short HEAD\"";
+      output String s "Creation meta data";
+    algorithm
+      s := "[ResultCreationLog]\nmodelName=\"" + modelName + "\"\n";
+      s := s + "\n// Test info\n";
+      s := s + "generationTool=\"" + DymolaVersion() + "\"\n";
+      s := s + "generationDateAndTime=\"" + command("getdatetime +\"%Y-%m-%dT%TZ\"") + "\"\n";
+      s := s + "usedGitURL=\"" + gitURL + "\"\n";
+      s := s + "usedGitRevision=" + gitRevision + "\n";
+      s := s + "testPC=\"" + hostname + "\"\n";
+      s := s + "testOS=\"" + osver + "\"\n";
+      s := s + "testUser=\"" + user + "\"\n";
+      s := s + "testDescription=\"" + description + "\"\n";
+      s := s + "\n// Experiment settings (standardized annotation)\n";
+      s := s + "StartTime=" + String(startTime);
+      if isDefaultStartTime then
+        s := s + "\n";
+      else
+        s := s + " // from model\n";
+      end if;
+      s := s + "StopTime=" + String(stopTime) + " // from model\n";
+      s := s + "Interval=" + String(interval);
+      if isDefaultInterval then
+        s := s + " // (stopTime-startTime)/" + String(numberOfIntervals) + "\n";
+      else
+        s := s + " // used annotation from model, multiplied by 0.5\n";
+      end if;
+      s := s + "Tolerance=" + String(tolerance);
+      if tolerance < 2e-12 then
+        s := s + " // used annotation from model, because attempt with tolerance of " + String(0.1*tolerance) + "\n";
+      elseif isDefaultTolerance then
+        s := s + " // used default, because no tolerance annotation in model\n";
+      else
+        s := s + " // used annotation from model, multiplied by 0.1\n";
+      end if;
+      s := s + "\n// Experiment settings (tool specific)\n";
+      s := s + "// The following lines can be used as mos-script in Dymola\n";
+      s := s + "SetDymolaCompiler(\"" + compiler + "\", {\"";
+      for i in 1:size(compilerSettings, 1) - 1 loop
+        s := s + compilerSettings[i] + "\", \"";
+      end for;
+      s := s + compilerSettings[end] + "\"});\n";
+      s := s + "Evaluate := false;\n";
+      s := s + "OutputCPUtime := false;\n";
+      s := s + "translateModel(\"" + modelName + "\");\n";
+      s := s + "Advanced.StoreProtectedVariables := true;\n";
+      s := s + "Advanced.EfficientMinorEvents := false;\n";
+      s := s + "experimentSetupOutput(\n";
+      s := s + "  textual=false,\n";
+      s := s + "  doublePrecision=true,\n";
+      s := s + "  states=true,\n";
+      s := s + "  derivatives=true,\n";
+      s := s + "  inputs=true,\n";
+      s := s + "  outputs=true,\n";
+      s := s + "  auxiliaries=true,\n";
+      s := s + "  equidistant=true,\n";
+      s := s + "  events=true,\n";
+      s := s + "  debug=false);\n";
+      s := s + "simulateModel(\n";
+      s := s + "  problem=\"" + modelName + "\",\n";
+      s := s + "  startTime=" + String(startTime) + ",\n";
+      s := s + "  stopTime=" + String(stopTime) + ",\n";
+      s := s + "  outputInterval=" + String(interval) + ",\n";
+      s := s + "  method=\"Dassl\",\n";
+      s := s + "  tolerance=" + String(tolerance) + ",\n";
+      s := s + "  resultFile=\"" + modelIdent + "\");";
+    end getCreation;
 
     function isInternalClass "Simple check if a class is internal"
       extends Modelica.Icons.Function;
@@ -201,5 +546,5 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
   equation
     der(x) = -x;
   end TestModel;
-  annotation (uses(Modelica(version="3.2.3"), ModelManagement(version="1.1.7")));
+  annotation (uses(DataFiles(version="1.0.5"), ModelManagement(version="1.1.8"), Modelica(version="3.2.3")));
 end ReleaseChecks;

--- a/ReleaseChecks.mo
+++ b/ReleaseChecks.mo
@@ -140,7 +140,7 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
       String StopTime;
       Boolean OK;
       String logStat;
-	  String fullName;
+      String fullName;
       AST.ClassAttributes classAttributes;
     algorithm
       logStat := "";
@@ -171,7 +171,7 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
           end if;
         end if;
       end for;
-	  annotation(__Dymola_interactive=true);
+      annotation(__Dymola_interactive=true);
     end inspectPackage;
 
     function inspectPackageEx "Simulate all executables blocks/models of a package and generate simulation results"
@@ -312,6 +312,7 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
                   print(logStat, fullPathName(modelDirectory + "/translate_passed.log"));
                   Advanced.StoreProtectedVariables := true;
                   Advanced.EfficientMinorEvents := false;
+                  Advanced.PlaceDymolaSourceFirst := 2; // See https://github.com/modelica/ModelicaStandardLibrary/pull/3453
                   OK := experimentSetupOutput(textual=false, doublePrecision=true, states=true, derivatives=true, inputs=true, outputs=true, auxiliaries=true, equidistant=true, events=true, debug=false);
 
                   // Simulate model
@@ -356,7 +357,7 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
           end if;
         end if;
       end for;
-	  annotation(__Dymola_interactive=true);
+      annotation(__Dymola_interactive=true);
     end inspectPackageEx;
 
     function scanReal "Scan Real value from string"
@@ -460,6 +461,7 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
       s := s + "translateModel(\"" + modelName + "\");\n";
       s := s + "Advanced.StoreProtectedVariables := true;\n";
       s := s + "Advanced.EfficientMinorEvents := false;\n";
+      s := s + "Advanced.PlaceDymolaSourceFirst := 2;\n";
       s := s + "experimentSetupOutput(\n";
       s := s + "  textual=false,\n";
       s := s + "  doublePrecision=true,\n";

--- a/ReleaseChecks.mo
+++ b/ReleaseChecks.mo
@@ -315,10 +315,21 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
                 print(logStat, fullPathName(modelDirectory + "/check_passed.log"));
 
                 // Translate model
+                // OK := translateModel(fullName);
+                // (logStat, , , ) := getLastError();
+                // Woraround for issue with getLastError not returning the complete translation log
+                Advanced.TranslationInCommandLog := true;
+                clearlog();
                 OK := translateModel(fullName);
-                (logStat, , , ) := getLastError();
                 if OK then
-                  print(logStat, fullPathName(modelDirectory + "/translate_passed.log"));
+                  logStat := fullPathName(modelDirectory + "/translate_passed.log");
+                else
+                  logStat := fullPathName(modelDirectory + "/translate_failed.log");
+                end if;
+                savelog(logStat);
+                Advanced.TranslationInCommandLog := false;
+                if OK then
+                  // print(logStat, fullPathName(modelDirectory + "/translate_passed.log"));
                   Advanced.StoreProtectedVariables := true;
                   Advanced.EfficientMinorEvents := false;
                   Advanced.PlaceDymolaSourceFirst := 2; // See https://github.com/modelica/ModelicaStandardLibrary/pull/3453
@@ -358,7 +369,7 @@ Generate HTML documentation from Modelica model or package in Dymola</p></html>"
                   end if;
                 else
                   nr[2] := nr[2] + 1;
-                  print(logStat, fullPathName(modelDirectory + "/translate_failed.log"));
+                  // print(logStat, fullPathName(modelDirectory + "/translate_failed.log"));
                 end if;
               else
                 nr[1] := nr[1] + 1;


### PR DESCRIPTION
Function simulateExecutables can be used to simulate all models/blocks of a Modelica library and create CSV files, to be used in post-processing such as regression analysis.